### PR TITLE
feat(CI): Add automated testing for Noir pre-releases

### DIFF
--- a/.github/workflows/noir-prerelease-test.yml
+++ b/.github/workflows/noir-prerelease-test.yml
@@ -1,0 +1,28 @@
+name: Test Noir Pre-releases
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs every day at midnight
+  workflow_dispatch:      # Allows manual triggering
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          
+      - name: Install dependencies
+        run: npm install
+        
+      - name: Run setup script
+        run: |
+          chmod +x ./tools/ci/setup.sh
+          ./tools/ci/setup.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/ci/setup.sh
+++ b/tools/ci/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Function to check the latest Noir pre-release
+check_noir_prerelease() {
+    # Fetch the latest pre-release through the GitHub API
+    LATEST_PRERELEASE=$(curl -s https://api.github.com/repos/noir-lang/noir/releases \
+        | jq -r '.[] | select(.prerelease == true) | .tag_name' | head -n 1)
+    
+    echo "Latest Noir pre-release: $LATEST_PRERELEASE"
+    return "$LATEST_PRERELEASE"
+}
+
+# Function to install a specific version of Noir
+install_noir_version() {
+    VERSION=$1
+    echo "Installing Noir version $VERSION"
+    
+    # Install nargo
+    curl -L https://raw.githubusercontent.com/noir-lang/noir/master/installer/install.sh | bash -s -- -v "$VERSION"
+}
+
+# Function to create a GitHub Issue upon detecting incompatibility
+create_github_issue() {
+    VERSION=$1
+    ERROR_MSG=$2
+    
+    if [ -n "$GITHUB_TOKEN" ]; then
+        curl -X POST "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "{
+                \"title\": \"Incompatibility with Noir ${VERSION}\",
+                \"body\": \"An incompatibility was detected while testing with version ${VERSION}:\\n\\n\`\`\`\\n${ERROR_MSG}\\n\`\`\`\"
+            }"
+    fi
+}
+
+# Main logic
+main() {
+    PRERELEASE=$(check_noir_prerelease)
+    install_noir_version "$PRERELEASE"
+    
+    # Run tests
+    if ! npm test; then
+        create_github_issue "$PRERELEASE" "Tests failed with version $PRERELEASE"
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
Closes #98

Added CI workflow to automatically test against Noir pre-releases:
- Created setup script to check and install latest Noir pre-releases
- Added GitHub Action with daily scheduled runs
- Automated issue creation for incompatibility detection

This helps to:
- Detect incompatibilities early
- Reduce manual testing effort
- Keep the starter up-to-date with Noir releases