### PR TITLE
fix: Incorrect payable Modifier Usage

### DIFF
--- a/with-foundry/lib/forge-std/src/interfaces/IERC721.sol
+++ b/with-foundry/lib/forge-std/src/interfaces/IERC721.sol
@@ -50,7 +50,7 @@ interface IERC721 is IERC165 {
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
     /// @param data Additional data with no specified format, sent in call to `_to`
-    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes calldata data) external payable;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes calldata data) external;
 
     /// @notice Transfers the ownership of an NFT from one address to another address
     /// @dev This works identically to the other function with an extra data parameter,
@@ -58,7 +58,7 @@ interface IERC721 is IERC165 {
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external;
 
     /// @notice Transfer ownership of an NFT -- THE CALLER IS RESPONSIBLE
     /// TO CONFIRM THAT `_to` IS CAPABLE OF RECEIVING NFTS OR ELSE
@@ -70,7 +70,7 @@ interface IERC721 is IERC165 {
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+    function transferFrom(address _from, address _to, uint256 _tokenId) external;
 
     /// @notice Change or reaffirm the approved address for an NFT
     /// @dev The zero address indicates there is no approved address.


### PR DESCRIPTION
The `payable` modifier allows a function to accept Ether (ETH) when it is called. In the `IERC721` interface, the functions `safeTransferFrom`, `transferFrom`, and `approve` are not designed to handle Ether transfers and are intended solely for managing NFTs.

By marking a function as `payable`, you enable the ability to send Ether when calling this function, which can result in unintended Ether being credited to the contract. This could lead to potential vulnerabilities or errors when interacting with the contract.