### PR TITLE
Fix incorrect implementation of `fail` function

### DIFF
--- a/with-foundry/lib/forge-std/src/StdAssertions.sol
+++ b/with-foundry/lib/forge-std/src/StdAssertions.sol
@@ -14,7 +14,7 @@ abstract contract StdAssertions is DSTest {
 
     function fail(string memory err) internal virtual {
         emit log_named_string("Error", err);
-        fail();
+        super.fail();
     }
 
     function assertFalse(bool data) internal virtual {


### PR DESCRIPTION
In the current implementation, the `fail` function calls itself without a termination condition, leading to infinite recursion. Instead of invoking the `fail` function from the parent `DSTest` contract, the current implementation loops on itself, making it impossible to properly execute tests and handle errors.